### PR TITLE
Update branch

### DIFF
--- a/Encoder/Encoder Core.lua
+++ b/Encoder/Encoder Core.lua
@@ -1,15 +1,35 @@
 --By Tipsy Hobbit
 mod_name = "Encoder"
 postfix = ''
-version = '4.4.01'
+version = '4.4.03'
 version_string = "Player,Menu and Style update."
-beta=false
 
 URLS={
   ENCODER='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Encoder%20Core.lua',
   ENCODER_BETA='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/update_branch/Encoder/Encoder%20Core.lua',
   XML='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/update_branch/Encoder/XML.json'
   }
+CORE_VALUE = {
+  menu_count = 0,
+  style_count = 0,
+  beta = false,
+  style = "Basic_Style"
+}
+basicstyleTableDefault = {
+  label='',
+  position={0,0.28,0},
+  rotation={0,0,0},
+  scale={1,1,1},
+  width=60,
+  height=60,
+  font_size=10,
+  color= {0,0,0,1},
+  font_color= {1,1,1,1},
+  hover_color= {0.3,0.3,0.3,1},
+  press_color= {0.6,0.6,0.6,1},
+  tooltip=""
+}
+
 
 EncodedObjects = {}
 --[[
@@ -41,9 +61,9 @@ Properties = {}
   name = external name,
   values = {},  --List of Values this property calls on. DOES NOT GET REGISTERED FROM HERE.
   funcOwner = obj,
-  callOnActivate = true,
   activateFunc ='callEditor',
   visible = true, --Should this property show up in the menu.
+  tags = '{json list}',--A json list of tags. 'tool,property,hidden'
   xml_index = tableindex
   }
 ]]
@@ -55,40 +75,34 @@ Values = {}
   props = {} list of properties that use this value.
   desc = A description for other module creators to understand the values use.
 ]]
-Tools = {}
---[[
-  toolID = internal name
-  name = external name
-  funcOwner = function owner
-  activateFunc = string
-  display = bool
-]]
 Zones = {}
 --[[
   name=Zone name
   activateFunc = function to call
 ]]
 Styles = {}
+Styles["Basic_Style"] = {name="Basic Style",desc="Comes with the encoder.",styleTable=basicstyleTableDefault}
 --[[
   styleID = internal name,
-  funcOwner = obj
-  --Encoder calls createStyleButton(t) from this to create buttons so they follow a standard style.
+  name = '',
+  desc = '',
+  styleTable = buttonTable
 ]]
-Styles["basic"] = {styleID = "basic",funcOwner = self} --The basic style that comes with the encoder.
 Menus = {}
 --[[
   menuID = internal name,
-  funcOwner = obj
-  --Encoder calls this to create its menus. createMenu({obj=obj})
+  funcOwner = obj,
+  activateFunc = func name --Encoder calls this to create the menus. 
 ]]
 
-basic_buttons = {}
+
 
 -- Preps the core code for module integration as well
 --   as load in any save_data
 -----------------------------------------------------
 -- @param save_data Game data from autosaves. 
 function onLoad(saved_data)
+  basic_buttons = {}
 	-- Version Display
   broadcastToAll(mod_name.." "..version..postfix,{0.2,0.2,0.2})
 	
@@ -114,24 +128,18 @@ function onLoad(saved_data)
           if Properties[i].funcOwner == nil then
             Properties[i] = nil
           else
-            buildPropFunction(i)
-          end
-        end
-      end
-    end
-    if loaded_data.tools ~= nil then
-      for i,v in pairs(loaded_data.tools) do
-        if i ~= nil and v ~= nil and v ~= "" then
-          Tools[i] = JSON.decode(v)
-          Tools[i].funcOwner = getObjectFromGUID(Tools[i].funcOwner)
-          if Tools[i].funcOwner == nil then
-            Tools[i] = nil
+            --buildPropFunction(i)
           end
         end
       end
     end
     if loaded_data.zones ~= nil then
       Zones = JSON.decode(loaded_data.zones)
+      for k,v in pairs(Zones) do
+        if getObjectFromGUID(k) == nil then
+          Zones[k] = nil
+        end
+      end
     end
     if loaded_data.values ~= nil then
       for i,v in pairs(loaded_data.values) do
@@ -159,17 +167,44 @@ function onLoad(saved_data)
         end
       end
     end
+    if loaded_data.menus ~= nil then
+      CORE_VALUE.menu_count = 0
+      for i,v in pairs(loaded_data.menus) do
+        if i ~= nil and v ~= nil and v ~= "" then
+          Menus[i] = JSON.decode(v)
+          Menus[i].funcOwner = getObjectFromGUID(Menus[i].funcOwner)
+          if Menus[i].funcOwner == nil then
+            Menus[i] = nil
+          else
+            CORE_VALUE.menu_count = CORE_VALUE.menu_count + 1
+          end
+        end
+      end
+      if CORE_VALUE.menu_count == 0 then
+        --log(CORE_VALUE.menu_count,"No menus currently exist.","missing_module")
+      end
+    end
+    if loaded_data.styles ~= nil then
+      Styles = JSON.decode(loaded_data.styles)
+      CORE_VALUE.style_count = 0
+      for i,v in pairs(Styles) do
+        CORE_VALUE.style_count = CORE_VALUE.style_count + 1
+      end
+      --log(CORE_VALUE.style_count,"No styles currently exist, will not be able to render buttons in a unified manner.","missing_module")
+    end
   end
+  
   buildZones()
+  
   for k,v in pairs(Player.getColors()) do
-    encodePlayer({ply=v})
+    encodePlayer(v)
   end
   createEncoderButtons()
   
   self.clearContextMenu()
   self.addContextMenuItem('Main Branch', function(p) 
     if Player[p].admin then
-      beta = false
+      CORE_VALUE.beta = false
       Player[p].broadcast('Switching back to the stable update branch.')
       Player[p].broadcast("Please don't forget to preform a version check to force the swith to occur.")
     else
@@ -179,7 +214,7 @@ function onLoad(saved_data)
   )
   self.addContextMenuItem('Beta Branch', function(p) 
     if Player[p].admin then
-      beta = true
+      CORE_VALUE.beta = true
       Player[p].broadcast('Switching to the un-stable update branch.')
       Player[p].broadcast("Please don't forget to preform a version check to force the swith to occur.")
       Player[p].broadcast("Bugs are to be expected.")
@@ -197,8 +232,13 @@ function onLoad(saved_data)
     end
   end
   )
-  
-  if beta then
+  self.addContextMenuItem('Refresh Style', function(p)
+    for k,v in pairs(Menus) do
+      v.funcOwner.call('refreshStyle',_)
+    end
+  end
+  )
+  if CORE_VALUE.beta then
     WebRequest.get(URLS['ENCODER_BETA'],self,"updateCheck")
   else
     WebRequest.get(URLS['ENCODER'],self,"updateCheck")
@@ -213,10 +253,11 @@ function onSave()
   local data_to_save = {}
   data_to_save["cards"] = {}
   data_to_save["properties"] = {}
-  data_to_save["tools"] = {}
   data_to_save["zones"] = JSON.encode(Zones)
   data_to_save["values"] = {}
   data_to_save["players"] = JSON.encode(Players)
+  data_to_save["menus"] = {}
+  data_to_save["styles"] = JSON.encode(Styles)
   
   for i,v in pairs(EncodedObjects) do
     --Removing Object reference before encoding.
@@ -236,32 +277,43 @@ function onSave()
       Properties[i].funcOwner = tempThis
     end
   end
-  for i,v in pairs(Tools) do
-    --Removing Object reference before encoding.
-    if Tools[i].funcOwner ~= nil then
-      local tempThis = Tools[i].funcOwner
-      Tools[i].funcOwner = Tools[i].funcOwner.getGUID()
-      data_to_save["tools"][i] = JSON.encode(v)
-      Tools[i].funcOwner = tempThis
-    end
-  end
   for i,v in pairs(Values) do
     local tempThis = Values[i].validate 
     Values[i].validate = ''
     data_to_save["values"][i] = JSON.encode(Values[i])
     Values[i].validate = tempThis
   end
+  for i,v in pairs(Menus) do
+    if Menus[i].funcOwner ~= nil then
+      local tempThis = Menus[i].funcOwner
+      Menus[i].funcOwner = Menus[i].funcOwner.getGUID()
+      data_to_save["menus"][i] = JSON.encode(Menus[i])
+      Menus[i].funcOwner = tempThis
+    end
+  end
   saved_data = JSON.encode(data_to_save)
   return saved_data
 end
 
 function callVersionCheck(p)
-  if beta then
+  if CORE_VALUE.beta then
     WebRequest.get(URLS['ENCODER_BETA'],self,"versionCheck")
   else
     WebRequest.get(URLS['ENCODER'],self,"versionCheck")
   end
   for k,v in pairs(Properties) do
+    u = v.funcOwner.getVar('UPDATE_URL')
+    if u ~= nil then
+      WebRequest.get(u,v.funcOwner,"updateModule") 
+    end
+  end
+  for k,v in pairs(Menus) do
+    u = v.funcOwner.getVar('UPDATE_URL')
+    if u ~= nil then
+      WebRequest.get(u,v.funcOwner,"updateModule") 
+    end
+  end
+  for k,v in pairs(Styles) do
     u = v.funcOwner.getVar('UPDATE_URL')
     if u ~= nil then
       WebRequest.get(u,v.funcOwner,"updateModule") 
@@ -282,7 +334,7 @@ function versionCheck(wr)
   wr = wr.text
   local ver = versionComp(string.match(wr,"version = '(.-)'"),version)
   if ''..ver ~= ''..version then
-    if beta == true then
+    if CORE_VALUE.beta == true then
       broadcastToAll("An update has been found for the beta branch. Reloading encoder.")
     else
       broadcastToAll("An update has been found for the main branch. Reloading encoder.")
@@ -387,8 +439,9 @@ function buildZones()
   for k,v in pairs(Player.getColors()) do
     if v ~= "Grey" then
     for i=1,Player[v].getHandCount() do
-      z = getObjectFromGUID(ZtoG[v..''..i])
+      z = getObjectFromGUID(ZtoG[v..'_Hand_'..i])
       if z == nil then
+        --error('Missing hand zone for '..v..''..i)
         h = Player[v].getHandTransform(i)
         local j = v
         local ind = i
@@ -400,7 +453,7 @@ function buildZones()
         params.scale = hs*(4/3)
         params.sound = false
         params.callback_function = function(obj) Zones[obj.guid] = {
-          name = j..''..ind,
+          name = j..'_Hand_'..ind,
           func_enter = 'hideCardDetails',
           func_leave = 'showCardDetails',
           color = j
@@ -461,6 +514,12 @@ function onObjectDestroyed(obj)
 				--UI.setAttribute(k.."MainMenu","active",false)
 			end
 		end
+    for k,v in pairs(Zones) do
+      o = getObjectFromGUID(k)
+      if o ~= nil then
+        o.destruct()
+      end
+    end
   end
 end
 function onObjectDropped(c,obj)
@@ -523,7 +582,7 @@ function encodeObject(o)
     oName = o.getName(),
     values = {},
     encoded = {},
-    menus = {props={open=false,pos=0},copy={open=false,pos=0}},
+    menus = {},
     editing = nil,
     flip = 1,
     disable = false
@@ -542,11 +601,9 @@ function encodePlayer(c)
       encoded = {},
       editing = nil,
       style = "basic",
-      menus = {},
-      token = nil
+      menus = {}
     }
-    buildButtons(c)
-    buildContextMenu(c)
+    --updateXML(c)
     return true
   end
   return false
@@ -587,173 +644,50 @@ function buildContextMenu(o)
 end
 
 function buildButtons(o)
-  for k,v in pairs(Menus)
-    v.funcOwner.call("createMenu",{obj=o,ply=p})
-  end
-end
-
---[[
-function buildButtons(o)
-  if type(o) == 'String' and Players[o] ~= nil then
-    for k,v in pairs(Players[o].encoded) do
-      if v == true and Properties[k]~=nil and Properties[k].funcOwner~= nil then
-        Properties[k].funcOwner.call("createButtons",{ply=o,obj=Players[o].token})
+  o.clearButtons()
+  o.clearInputs()
+  if EncodedObjects[o.getGUID()].disable ~= true then
+    if EncodedObjects[o.getGUID()].editing == nil then
+      count = 0
+      for k,v in pairs(Menus) do
+        if v.funcOwner ~= nil then
+          if EncodedObjects[o.getGUID()].menus[k] == nil then
+            EncodedObjects[o.getGUID()].menus[k] = {open=false,pos=0}
+          end
+          v.funcOwner.call(v.activateFunc,{obj=o,style=Styles[CORE_VALUE.style].styleTable})
+          count = count+1
+        else
+          --log(v.funcOwner,"Missing module for menu "..k,'missing_module')
+        end
       end
-    end
-  else
-    o.clearButtons()
-    o.clearInputs()
-    if EncodedObjects[o.getGUID()].disable ~= true then
-      local flip = EncodedObjects[o.getGUID()].flip
-      local scaler = {x=1,y=1,z=1}--o.getScale()
-      zpos = 0.28*flip*scaler.z
-      if EncodedObjects[o.getGUID()].editing == nil then
-        if EncodedObjects[o.getGUID()].menus.copy.open == false then
-          o.createButton({
-          label=">\n>\n>", click_function='toggleCopyMenu', function_owner=self,
-          position={1*flip*scaler.x,zpos,-0.7*scaler.y}, height=250, width=10, font_size=60,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1},tooltip="Tool Menu"
-          })
-        else
-          o.createButton({
-          label="<\n<\n<", click_function='toggleCopyMenu', function_owner=self,
-          position={1*flip*scaler.x,zpos,-0.7*scaler.y}, height=250, width=10, font_size=60,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1},tooltip="Tool Menu"
-          })
-          temp = "Disable Encoding"
-          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,-1,0)
-          o.createButton({
-          label=temp, click_function='disableEncoding', function_owner=self,
-          position={(1.05+offset_x)*flip*scaler.x,zpos,(1.5+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,0,0,1}
-          })
-          temp = "↿     ↾"
-          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,-1,0)
-          o.createButton({
-          label=temp, click_function='CMscrollUp', function_owner=self,
-          position={(1.05+offset_x)*flip*scaler.x,zpos,(-1+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
-          })
-          temp = "⇃     ⇂"
-          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,-1,0)
-          o.createButton({
-          label=temp, click_function='CMscrollDown', function_owner=self,
-          position={(1.05+offset_x)*flip*scaler.x,zpos,1*scaler.y}, height=100, width=barSize, font_size=fsize,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
-          })
-          local count = 0
-          local pos = EncodedObjects[o.getGUID()].menus.copy.pos
-          for k,v in pairsByKeys(Tools) do
-            if v.display==true and v.funcOwner ~= nil then
-              if pos <= count and count < pos+7 then
-                temp = v.name
-                barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,-1,0)
-                o.createButton({
-                label=temp, click_function=v.activateFunc, function_owner=v.funcOwner,
-                position={(1.05+offset_x)*flip*scaler.x,zpos,(-0.75+((count-pos)/3)+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
-                rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
-                })
-              end
-              count = count+1
-            end
-          end
-        end
-        if EncodedObjects[o.getGUID()].menus.props.open == false then
-          o.createButton({
-          label="<\n<\n<", click_function='togglePropMenu', function_owner=self,
-          position={-1.0*flip*scaler.x,zpos,-0.7*scaler.y}, height=250, width=10, font_size=60,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1},tooltip="Module Menu"
-          })
-        else
-          o.createButton({
-          label=">\n>\n>", click_function='togglePropMenu', function_owner=self,
-          position={-1.0*flip*scaler.x,zpos,-0.7*scaler.y}, height=250, width=10, font_size=60,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1},tooltip="Module Menu"
-          })
-          temp = " Flip "
-          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,1,0)
-          o.createButton({
-          label=temp, click_function='flipMenu', function_owner=self,
-          position={(-1.05+offset_x)*flip*scaler.x,zpos,(1.25+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
-          })
-          temp = "↿     ↾"
-          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,1,0)
-          o.createButton({
-          label=temp, click_function='PMscrollUp', function_owner=self,
-          position={(-1.05+offset_x)*flip*scaler.x,zpos,(-1+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
-          })
-          temp = "⇃     ⇂"
-          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,1,0)
-          o.createButton({
-          label=temp, click_function='PMscrollDown', function_owner=self,
-          position={(-1.05+offset_x)*flip*scaler.x,zpos,(1+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
-          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
-          })
-          
-          local count = 0
-          local pos = EncodedObjects[o.getGUID()].menus.props.pos
-          for k,v in pairsByKeys(Properties) do
-            if v.funcOwner ~= nil and v.visible ~= false then
-              if pos <= count and count < pos+7 then
-                temp = v.name
-                barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,1,0)
-                o.createButton({
-                label=temp, click_function=v.propID..'Toggle', function_owner=self,
-                position={(-1.05+offset_x)*flip*scaler.x,zpos,(-0.75+((count-pos)/3.9)+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
-                rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
-                })
-              end
-              count = count+1
-            end
-          end
-        end
-        
-        for k,v in pairs(EncodedObjects[o.getGUID()].encoded) do
-          if v == true and Properties[k]~=nil and Properties[k].funcOwner~= nil then
-            --print(k)
-            Properties[k].funcOwner.call("createButtons",{obj=o})
-          end
-        end
-      else
-        k = EncodedObjects[o.getGUID()].editing
-        if Properties[k]~=nil and Properties[k].funcOwner~= nil then
+      if count == 0 then
+        --log(count,"No menus exist, cannot render to cards.",'missing_module')
+      end
+      for k,v in pairs(EncodedObjects[o.getGUID()].encoded) do
+        if v == true and Properties[k]~=nil and Properties[k].funcOwner~= nil then
           Properties[k].funcOwner.call("createButtons",{obj=o})
         end
-        temp = " X "
-        barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,0,0)
-        o.createButton({
-        label=temp, click_function='closeEditor', function_owner=self,
-        position={(-1.1+offset_x)*flip,zpos,(1.4+offset_y)}, height=100, width=barSize, font_size=fsize,
-        rotation={0,0,90-90*flip}
-        })
       end
+    else
+      k = EncodedObjects[o.getGUID()].editing
+      if Properties[k]~=nil and Properties[k].funcOwner~= nil then
+        Properties[k].funcOwner.call("createButtons",{obj=o})
+      end
+      temp = " X "
+      barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,0,0)
+      o.createButton({
+      label=temp, click_function='closeEditor', function_owner=self,
+      position={(-1.1+offset_x)*flip,zpos,(1.4+offset_y)}, height=100, width=barSize, font_size=fsize,
+      rotation={0,0,90-90*flip}
+      })
     end
   end
 end
-]]
-function CMscrollDown(o,p)
-  if EncodedObjects[o.getGUID()].menus.copy.pos < length(Properties) then
-    EncodedObjects[o.getGUID()].menus.copy.pos = EncodedObjects[o.getGUID()].menus.copy.pos+1
-  end
-  buildButtons(o)
-end
-function CMscrollUp(o,p)
-  if EncodedObjects[o.getGUID()].menus.copy.pos > 0 then
-    EncodedObjects[o.getGUID()].menus.copy.pos = EncodedObjects[o.getGUID()].menus.copy.pos-1
-  end
-  buildButtons(o)
-end
-function PMscrollDown(o,p)
-  if EncodedObjects[o.getGUID()].menus.props.pos < length(Properties) then
-    EncodedObjects[o.getGUID()].menus.props.pos = EncodedObjects[o.getGUID()].menus.props.pos+1
-  end
-  buildButtons(o)
-end
-function PMscrollUp(o,p)
-  if EncodedObjects[o.getGUID()].menus.props.pos > 0 then
-    EncodedObjects[o.getGUID()].menus.props.pos = EncodedObjects[o.getGUID()].menus.props.pos-1
+function closeEditor(o)
+  if type(o) == 'String' then
+    Players[o].editing = nil
+  else
+    EncodedObjects[o.getGUID()].editing = nil
   end
   buildButtons(o)
 end
@@ -772,8 +706,6 @@ function disableEncoding(o,p)
   end
   buildButtons(o)
 end
-
-
 function flipMenu(o,p)
   local flip = EncodedObjects[o.getGUID()].flip
   if flip ~= 1 then
@@ -792,22 +724,6 @@ function flipMenu(o,p)
         end
       end
     end
-  end
-  buildButtons(o)
-end
-function toggleCopyMenu(o)
-  if EncodedObjects[o.getGUID()].menus.copy.open ~= true then
-    EncodedObjects[o.getGUID()].menus.copy.open = true
-  else
-    EncodedObjects[o.getGUID()].menus.copy.open = false
-  end
-  buildButtons(o)
-end
-function togglePropMenu(o)
-  if EncodedObjects[o.getGUID()].menus.props.open ~= true then
-    EncodedObjects[o.getGUID()].menus.props.open = true
-  else
-    EncodedObjects[o.getGUID()].menus.props.open = false
   end
   buildButtons(o)
 end
@@ -848,17 +764,10 @@ function toggleProperty(o,p)
     return Players[o].encoded[p]
   end
 end
-function closeEditor(o)
-  if type(o) == 'String' then
-    Players[o].editing = nil
-  else
-    EncodedObjects[o.getGUID()].editing = nil
-  end
-  buildButtons(o)
-end
+
 
 -- Factories
-function buildPropFunction(p)
+--[[function buildPropFunction(p)
   local pdat = Properties[p]
   _G[p.."Toggle"] = function(obj,ply) 
     enabled = toggleProperty(obj,p)
@@ -892,6 +801,7 @@ function buildPropFunction(p)
     end
   end
 end
+]]
 function buildValueValidationFunction(p)
   v=Values[p]
   if v.validType ~= nil and v.validType ~= 'nil' then
@@ -915,7 +825,10 @@ function buildValueValidationFunction(p)
   end
   _G[p..'validate']= Values[p]['validate']
 end
--- API Functions
+
+
+--##########################
+--#API Functions
 --[[Almost all function within the api require a table to be passed to them.
 Table keys that are used are as follows.
 obj = the object that is the target of the api call. RW
@@ -928,38 +841,91 @@ not all of the values are required for every API function.
 ]]
 
 --REGISTRATION
+
+--##########################
+--#PROPERTY FUNCTIONS
 --[[register a new property.
   Takes a table
   {propID='internalname',name='Button name',values={list of values},funcOwner=obj,callOnActivate=boolean,activateFunc='function name'}
 ]]
 function APIregisterProperty(p)
+--[[propID = internal name,
+  name = external name,
+  values = {},  --List of Values this property calls on. DOES NOT GET REGISTERED FROM HERE.
+  funcOwner = obj,
+  callOnActivate = true,
+  activateFunc ='callEditor',
+  visible = true, --Should this property show up in the menu.
+  tags = {list},--A list of tags. 'tool,property,hidden'
+  xml_index = tableindex
+  }]]
   Properties[p.propID] = deepcopy(p)
   print(Properties[p.propID].propID.." Registered")
-  buildPropFunction(p.propID)
+  --buildPropFunction(p.propID)
 	--updateUI()
 end
 --Lists currently registered properties.
-function APIlistProps()
+function APIgetPropsList(p)
+  tags = {}
+  if p ~= nil and p.tags ~= nil then
+    for k,v in pairs(p.tags) do
+      tags[k] = v
+    end
+  end
   data = {}
   for k,v in pairs(Properties) do
-    if v.funcOwner == nil then
-      data[k]='[Red]MISSING![White]'
+    if #tags ~= 0 then
+      if v.tags == nil or v.tags == '' then
+        Properties[k].tags = 'untagged'
+      end
+      for i=1, #tags do
+        if string.find(v.tags,tags[i]) then
+          if v.funcOwner == nil then
+            data[k]='[Red]MISSING![White]'
+          else
+            data[k]=''
+          end
+          data[k]=data[k]..v.propID.." : "..v.name.." {"
+          for m,n in pairs(v.values) do
+            data[k]=data[k]..n..","
+          end
+          data[k]=data[k].."}"
+          break;
+        end
+      end
     else
-      data[k]=''
+      if v.funcOwner == nil then
+        data[k]='[Red]MISSING![White]'
+      else
+        data[k]=''
+      end
+      data[k]=data[k]..v.propID.." : "..v.name.." {"
+      for m,n in pairs(v.values) do
+        data[k]=data[k]..n..","
+      end
+      data[k]=data[k].."}"
     end
-    data[k]=data[k]..v.propID.." : "..v.name.." {"
-    for m,n in pairs(v.values) do
-      data[k]=data[k]..n..","
-    end
-    data[k]=data[k].."}"
   end
   return data
 end
---register a new tool
-function APIregisterTool(p)
-  Tools[p.toolID] = deepcopy(p)
-  print(Tools[p.toolID].toolID.." Registered")
+--checks if a given property is registered, returns BOOL
+function APIpropertyExists(p)
+  return Properties[p.propID] ~= nil
 end
+--returns a list of values the property ues.
+function APIgetPropValues(p)
+  if Properties[p.propID] ~= nil then
+    return Properties[p.propID].values
+  end
+  return {}
+end
+--Returns the Property Table
+function APIgetProp(p)
+  return Properties[p.propID]
+end
+
+--##########################
+--#VALUE FUNCTIONS
 --[[register a new value.
   Takes a table
   {valueID='internalname',validType=#CHECK_VALID_TYPES,desc='What is it used for',default=value}
@@ -975,7 +941,6 @@ function APIregisterValue(p)
     Values[p.valueID] = {}
     Values[p.valueID]['default']= p.default
     Values[p.valueID]['validType']= p.validType
-    Values[p.valueID]['props']={}
     Values[p.valueID]['desc']= p.desc ~= nil and p.desc or 'No Description Given'
     buildValueValidationFunction(p.valueID)
   --end
@@ -989,116 +954,124 @@ function APIlistValues()
   end
   return data
 end
+--checks if a given value is registered, returns BOOL
+function APIvalueExists(p)
+  return Values[p.valueID] ~= nil
+end
+
+--##########################
+--#MENU FUNCTIONS
+--[[Register a new menu. ]]
+function APIregisterMenu(p)
+  Menus[p.menuID] = {
+    menuID = p.menuID,
+    funcOwner = p.funcOwner,
+    activateFunc = p.activateFunc
+   }
+end
+function APIlistMenus()
+  data = {}
+  for k,v in pairs(Menus) do
+    table.insert(data,k)
+  end
+  return data
+end
+--Get or Set menu data of a given object.
+--{obj=obj,menuID=menu ID,data=data}
+function APIobjGetMenuData(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil then
+    data = EncodedObjects[target].menus[p.menuID]
+    if data == nil then
+      data = {open=false,pos=0}
+    end
+    return data
+  end
+end
+function APIobjSetMenuData(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil then
+    if EncodedObjects[target].menus[p.menuID] == nil then
+      EncodedObjects[target].menus[p.menuID] = {open=false,pos=0}
+    end
+    for k,v in pairs(p.data) do
+      EncodedObjects[target].menus[p.menuID][k] = v
+    end
+  end
+end
+function APIobjToggleMenu(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil then
+    if EncodedObjects[target].menus[p.menuID] == nil then
+      EncodedObjects[target].menus[p.menuID] = {open=false,pos=0}
+    end
+    if EncodedObjects[target].menus[p.menuID].open ~= true then
+      EncodedObjects[target].menus[p.menuID].open = true
+    else
+      EncodedObjects[target].menus[p.menuID].open = false
+    end
+  end
+end
+
+--##########################
+--#STYLE FUNCTIONS
+function APIregisterStyle(p)
+  Styles[p.styleID] = {
+    styleID = p.styleID,
+    name = p.name,
+    desc = p.desc,
+    styleTable = p.styleTable
+  }
+end
+function APIlistStyles()
+  data = {}
+  for k,v in pairs(Styles) do
+    data[k] = v.styleID.." = "..v.name..":"..v.desc
+  end
+  return data
+end
+function APIsetGlobalStyle(p)
+  if Styles[p.styleID] ~= nil then
+    CORE_VALUE.style = p.styleID
+  end
+end
+function APIgetGlobalStyle()
+  return CORE_VALUE.style
+end
+function APIgetStyleTable()
+  return Styles[CORE_VALUE.style].styleTable
+end
+
+--##########################
+--#GETTERS/SETTERS
+
+--OBJECT/PLAYER FUNCTIONS
+--Toggles target prop on or off: {obj=obj,propID=propID}
+function APItoggleProperty(p)
+  if p.obj ~= nil then
+    toggleProperty(p.obj,p.propID)
+  end
+  if p.ply ~= nil then
+    toggleProperty(p.ply,p.propID)
+  end
+end
+
+--OBJECT FUNCTIONS
 --registers a new object to be encoded.
 function APIencodeObject(p)
   encodeObject(p.obj)
-end
---registers a new Player color to be encoded.
-function APIencodePlayer(p)
-  encodePlayer(p.ply)
-end
-
---GETTERS/SETTERS
---checks if a given property is registered, returns BOOL
-function APIpropertyExists(p)
-  return Properties[p.propID] ~= nil
 end
 --checks if a given object is encoded, returns BOOL
 function APIobjectExists(p)
   return EncodedObjects[p.obj.getGUID()] ~= nil
 end
---checks if a given value is registered, returns BOOL
-function APIvalueExists(p)
-  return Values[p.valueID] ~= nil
-end
---checks if a given player color is registered, returns BOOL
-function APIplayerExists(p)
-  return Players[p.ply] ~= nil
-end
-
-function APIgetPropValues(p)
-  if Properties[p.propID] ~= nil then
-    return Properties[p.propID].values
-  end
-  return {}
-end
-
---Get or Set a single value based on valueID. Returns the value.
---{obj=obj,valueID=valueID,data={valueID=value}}
-function APIobjGetValueData(p)
-  local target = p.obj.getGUID()
-  if EncodedObjects[target] ~= nil and Values[p.valueID] ~= nil then
-    if EncodedObjects[target].values[p.valueID] == nil then
-      EncodedObjects[target].values[p.valueID] = Values[p.valueID].default
-    end
-    val = EncodedObjects[target].values[p.valueID]
-    data = {}
-    data[p.valueID]=val
-    return data
-  end
-end
-function APIobjSetValueData(p)
-  local target = p.obj.getGUID()
-  if EncodedObjects[target] ~= nil and Values[p.valueID] ~= nil then
-    EncodedObjects[target].values[p.valueID] = _G[p.valueID.."Validate"](p.data[p.valueID],EncodedObjects[target].values[p.valueID])
-  end
-end
-function APIobjDefaultValue(p)
-  local target = p.obj.getGUID()    
-  if EncodedObjects[target] ~= nil and  Values[p.valueID] ~= nil then
-    EncodedObjects[target].values[p.valueID] = Values[p.valueID].default
-  end
-end
---{ply=color,valueID=valueID,data={valueID=value}}
-function APIplyGetValueData(p)
-  local target = p.ply
-  if Players[target] ~= nil and Values[p.valueID] ~= nil then
-    if Players[target].values[p.valueID] == nil then
-      Players[target].values[p.valueID] = Values[p.valueID].default
-    end
-    val = Players[target].values[p.valueID]
-    data = {}
-    data[p.valueID]=val
-    return data
-  end
-end
-function APIplySetValueData(p)
-  local target = p.ply
-  if Players[target] ~= nil and Values[p.valueID] ~= nil then
-    Players[target].values[p.valueID] = _G[p.valueID.."Validate"](p.data[p.valueID],Players[target].values[p.valueID])
-  end
-end
-function APIplyDefaultValue(p)
-  local target = p.ply    
-  if Players[target] ~= nil and  Values[p.valueID] ~= nil then
-    Players[target].values[p.valueID] = Values[p.valueID].default
-  end
-end
-
---Get or Set value data based on propID. Returns and accepts an array of Key-Values. Key is a valid valueID.
---{obj=obj,propID=propID,data={valueID=value}}
-function APIobjGetPropData(p)
+--Returns if the object is disabled or not.
+function APIobjDisabled(p)
   local target = p.obj.getGUID()
   if EncodedObjects[target] ~= nil then
-    data = {}
-    for k,v in pairs(Properties[p.propID].values) do
-      if EncodedObjects[target].values[v] == nil and  Values[v] ~= nil then
-        EncodedObjects[target].values[v] = Values[v].default
-      end
-      data[v]=EncodedObjects[target].values[v]
-    end
-    return data
+    return EncodedObjects[target].disable
   end
-end
-function APIobjSetPropData(p)
-  local target = p.obj.getGUID()
-  if EncodedObjects[target] ~= nil then
-    for k,v in pairs(Properties[p.propID].values) do
-      if Values[v] ~= nil and p.data[v] ~= nil then
-        EncodedObjects[target].values[v] = Values[v]["validate"](p.data[v],EncodedObjects[target].values[v])
-      end
-    end
-  end
+  return false
 end
 --Is a given Property enabled: {obj=obj,propID=propID}
 function APIobjIsPropEnabled(p)
@@ -1146,37 +1119,87 @@ function APIobjDisableProp(p)
     end
   end
 end
---Toggles target prop on or off: {obj=obj,propID=propID}
-function APItoggleProperty(p)
-  if p.obj ~= nil then
-    toggleProperty(p.obj,p.propID)
-  else
-    toggleProperty(p.ply,p.propID)
+--Get or Set a single value based on valueID. Returns the value.
+--{obj=obj,valueID=valueID,data={valueID=value}}
+function APIobjGetValueData(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil and Values[p.valueID] ~= nil then
+    if EncodedObjects[target].values[p.valueID] == nil then
+      EncodedObjects[target].values[p.valueID] = Values[p.valueID].default
+    end
+    val = EncodedObjects[target].values[p.valueID]
+    data = {}
+    data[p.valueID]=val
+    return data
   end
 end
-
-function APIplyGetPropData(p)
-  local target = p.ply
-  if Players[target] ~= nil then
+function APIobjSetValueData(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil and Values[p.valueID] ~= nil then
+    EncodedObjects[target].values[p.valueID] = _G[p.valueID.."Validate"](p.data[p.valueID],EncodedObjects[target].values[p.valueID])
+  end
+end
+function APIobjDefaultValue(p)
+  local target = p.obj.getGUID()    
+  if EncodedObjects[target] ~= nil and  Values[p.valueID] ~= nil then
+    EncodedObjects[target].values[p.valueID] = Values[p.valueID].default
+  end
+end
+--Get or Set value data based on propID. Returns and accepts an array of Key-Values. Key is a valid valueID.
+--{obj=obj,propID=propID,data={valueID=value}}
+function APIobjGetPropData(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil then
     data = {}
     for k,v in pairs(Properties[p.propID].values) do
-      if Players[target].values[v] == nil and  Values[v] ~= nil then
-        Players[target].values[v] = Values[v].default
+      if EncodedObjects[target].values[v] == nil and  Values[v] ~= nil then
+        EncodedObjects[target].values[v] = Values[v].default
       end
-      data[v]=Players[target].values[v]
+      data[v]=EncodedObjects[target].values[v]
     end
     return data
   end
 end
-function APIplySetPropData(p)
-  local target = p.ply
-  if Players[target] ~= nil then
+function APIobjSetPropData(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil then
     for k,v in pairs(Properties[p.propID].values) do
       if Values[v] ~= nil and p.data[v] ~= nil then
-        Players[target].values[v] = Values[v]["validate"](p.data[v],Players[target].values[v])
+        EncodedObjects[target].values[v] = Values[v]["validate"](p.data[v],EncodedObjects[target].values[v])
       end
     end
   end
+end
+--Get or Set all value data of a given object.
+--{obj=obj}
+function APIobjGetAllData(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil then
+   return EncodedObjects[target].values
+  end
+end
+--{obj=obj,data={valueID=value}}
+function APIobjSetAllData(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil then
+    for k,v in pairs(p.data) do
+      if Values[k] ~= nil then
+        EncodedObjects[target].values[k] = _G[k.."Validate"](v,EncodedObjects[target].values[k])
+      else
+        --log(k,'Unknown value '..k..'.','value')
+      end
+    end
+  end
+end
+
+--PLAYER FUNCTIONS
+--registers a new Player color to be encoded.
+function APIencodePlayer(p)
+  encodePlayer(p.ply)
+end
+--checks if a given player color is registered, returns BOOL
+function APIplayerExists(p)
+  return Players[p.ply] ~= nil
 end
 --Is a given Property enabled: {ply=color,propID=propID}
 function APIplyIsPropEnabled(p)
@@ -1224,24 +1247,52 @@ function APIplyDisableProp(p)
     end
   end
 end
-
---Get or Set all value data of a given object.
---{obj=obj}
-function APIobjGetAllData(p)
-  local target = p.obj.getGUID()
-  if EncodedObjects[target] ~= nil then
-   return EncodedObjects[target].values
+--{ply=color,valueID=valueID,data={valueID=value}}
+function APIplyGetValueData(p)
+  local target = p.ply
+  if Players[target] ~= nil and Values[p.valueID] ~= nil then
+    if Players[target].values[p.valueID] == nil then
+      Players[target].values[p.valueID] = Values[p.valueID].default
+    end
+    val = Players[target].values[p.valueID]
+    data = {}
+    data[p.valueID]=val
+    return data
   end
 end
---{obj=obj,data={valueID=value}}
-function APIobjSetAllData(p)
-  local target = p.obj.getGUID()
-  if EncodedObjects[target] ~= nil then
-    for k,v in pairs(p.data) do
-      if Values[k] ~= nil then
-        EncodedObjects[target].values[k] = _G[k.."Validate"](v,EncodedObjects[target].values[k])
-      else
-        error('Unknown value '..k..'.')
+function APIplySetValueData(p)
+  local target = p.ply
+  if Players[target] ~= nil and Values[p.valueID] ~= nil then
+    Players[target].values[p.valueID] = _G[p.valueID.."Validate"](p.data[p.valueID],Players[target].values[p.valueID])
+  end
+end
+function APIplyDefaultValue(p)
+  local target = p.ply    
+  if Players[target] ~= nil and  Values[p.valueID] ~= nil then
+    Players[target].values[p.valueID] = Values[p.valueID].default
+  end
+end
+--Get or Set value data based on propID. Returns and accepts an array of Key-Values. Key is a valid valueID.
+--{ply=ply,propID=propID,data={valueID=value}}
+function APIplyGetPropData(p)
+  local target = p.ply
+  if Players[target] ~= nil then
+    data = {}
+    for k,v in pairs(Properties[p.propID].values) do
+      if Players[target].values[v] == nil and  Values[v] ~= nil then
+        Players[target].values[v] = Values[v].default
+      end
+      data[v]=Players[target].values[v]
+    end
+    return data
+  end
+end
+function APIplySetPropData(p)
+  local target = p.ply
+  if Players[target] ~= nil then
+    for k,v in pairs(Properties[p.propID].values) do
+      if Values[v] ~= nil and p.data[v] ~= nil then
+        Players[target].values[v] = Values[v]["validate"](p.data[v],Players[target].values[v])
       end
     end
   end
@@ -1261,13 +1312,14 @@ function APIplySetAllData(p)
       if Values[k] ~= nil then
         Players[target].values[k] = _G[k.."Validate"](v,Players[target].values[k])
       else
-        error('Unknown value '..k..'.')
+        --log(k,'Unknown value '..k..'.','value')
       end
     end
   end
 end
 
- 
+
+
  
 --BUTTON UI FUNCTIONS
 --sets current editing state, so that buttons don't overlap. 
@@ -1301,8 +1353,11 @@ function APIrebuildButtons(p)
   if p.obj ~= nil then
     buildButtons(p.obj)
   else
-    buildButtons(p.ply)
+    updateXML(p.ply)
   end
+end
+function APIformatButton(p)
+  return updateSize(p.str,p.font_size,p.max_len,p.xJust,p.yJust)
 end
 --Flips which side of the card the buttons show up on.
 function APIFlip(p)
@@ -1324,9 +1379,6 @@ end
 function APIgetOName(p)
 	return EncodedObjects[p.obj.getGUID()].oName
 end
-function APIformatButton(p)
-  return updateSize(p.str,p.font_size,p.max_len,p.xJust,p.yJust)
-end
 --Compares two version strings '###.##.###.##' which is made up of any number of digits and periods.
 function APIversionComp(p)
   return versionComp(p.wv,p.cv)
@@ -1340,13 +1392,6 @@ end
 
 
 -- Tool Functions
-function length(t)
-  local count = 0
-  for k,v in pairs(t) do
-    count = count+1
-  end
-  return count
-end
 function deepcopy(orig)
     local orig_type = type(orig)
     local copy
@@ -1361,23 +1406,4 @@ function deepcopy(orig)
     end
     return copy
 end
-function waitFrames(num_frames)
-    for i=0, num_frames, 1 do
-        coroutine.yield(0)
-    end
-    num_frames = 1
-    return 1
-end
-function pairsByKeys (t, f)
-	local a = {}
-	for n in pairs(t) do table.insert(a, n) end
-	table.sort(a, f)
-	local i = 0      -- iterator variable
-	local iter = function ()   -- iterator function
-		i = i + 1
-		if a[i] == nil then return nil
-		else return a[i], t[a[i]]
-		end
-	end
-	return iter
-end
+

--- a/Encoder/Encoder Core.lua
+++ b/Encoder/Encoder Core.lua
@@ -1,7 +1,7 @@
 --By Tipsy Hobbit
 mod_name = "Encoder"
 postfix = ''
-version = '4.4.05'
+version = '4.4.06'
 version_string = "Player,Menu and Style update."
 
 URLS={
@@ -242,6 +242,11 @@ function onLoad(saved_data)
     WebRequest.get(URLS['ENCODER_BETA'],self,"updateCheck")
   else
     WebRequest.get(URLS['ENCODER'],self,"updateCheck")
+  end
+  
+  if CORE_VALUE.menu_count == 0 then
+    broadcastToAll("The card menu has been split into its own module. Please load it off the workshop page.")
+    Wait.time(function()broadcastToAll("The card menu has been split into its own module. Please load it off the workshop page.")end,5)
   end
   
 	--WebRequest.get(URLS['XML'],self,"buildUI")

--- a/Encoder/Encoder Core.lua
+++ b/Encoder/Encoder Core.lua
@@ -1,7 +1,7 @@
 --By Tipsy Hobbit
 mod_name = "Encoder"
 postfix = ''
-version = '4.4.03'
+version = '4.4.05'
 version_string = "Player,Menu and Style update."
 
 URLS={
@@ -654,7 +654,7 @@ function buildButtons(o)
           if EncodedObjects[o.getGUID()].menus[k] == nil then
             EncodedObjects[o.getGUID()].menus[k] = {open=false,pos=0}
           end
-          v.funcOwner.call(v.activateFunc,{obj=o,style=Styles[CORE_VALUE.style].styleTable})
+          v.funcOwner.call(v.activateFunc,{obj=o})
           count = count+1
         else
           --log(v.funcOwner,"Missing module for menu "..k,'missing_module')
@@ -673,11 +673,12 @@ function buildButtons(o)
       if Properties[k]~=nil and Properties[k].funcOwner~= nil then
         Properties[k].funcOwner.call("createButtons",{obj=o})
       end
+      flip = EncodedObjects[o.getGUID()].flip
       temp = " X "
       barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,0,0)
       o.createButton({
       label=temp, click_function='closeEditor', function_owner=self,
-      position={(-1.1+offset_x)*flip,zpos,(1.4+offset_y)}, height=100, width=barSize, font_size=fsize,
+      position={(-1.1+offset_x)*flip,0.28*flip,(1.4+offset_y)}, height=100, width=barSize, font_size=fsize,
       rotation={0,0,90-90*flip}
       })
     end

--- a/Encoder/Encoder Core.lua
+++ b/Encoder/Encoder Core.lua
@@ -1,8 +1,8 @@
 --By Tipsy Hobbit
 mod_name = "Encoder"
 postfix = ''
-version = '4.4.00'
-version_string = "Apperently I am not needed. GLHF"
+version = '4.4.01'
+version_string = "Player,Menu and Style update."
 beta=false
 
 URLS={
@@ -588,7 +588,7 @@ end
 
 function buildButtons(o)
   for k,v in pairs(Menus)
-    v.funcOwner.call("createMenu",o)
+    v.funcOwner.call("createMenu",{obj=o,ply=p})
   end
 end
 

--- a/Encoder/Extras/Encoder AutoRegister.lua
+++ b/Encoder/Extras/Encoder AutoRegister.lua
@@ -59,7 +59,7 @@ function onObjectDropped(c,object)
         object.setLock(true)
 				
 				start = 0
-				modules = tableMerge(enc.getTable("Properties"),enc.getTable("Tools"))
+				modules = tableMerge(enc.getTable("Properties"),enc.getTable("Menus"))
 				count = 0
 				
 				startPos = addVectors(self.getPosition(),multVectors(self.getTransformUp(),1))
@@ -97,7 +97,7 @@ function Float()
   start = 0
   while self ~= nil and cour == true do
     if enc ~= nil then
-      modules = tableMerge(enc.getTable("Properties"),enc.getTable("Tools"))
+      modules = tableMerge(enc.getTable("Properties"),enc.getTable("Menus"))
       count = 0
 			
 			startPos = addVectors(self.getPosition(),multVectors(self.getTransformUp(),1))

--- a/Encoder/Modules/Encoder_11Counter_Addon.lua
+++ b/Encoder/Modules/Encoder_11Counter_Addon.lua
@@ -4,7 +4,7 @@ This module adds only 1/1 Counters
 ]]
 pID = "MTG_11_Counters"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_11Counter_Addon.lua'
-version = '1.3'
+version = '1.4'
 
 function onload()
   self.createButton({
@@ -23,8 +23,9 @@ function registerModule()
     name = "+1/+1 Counters",
     values = {'oneOneCounter','moduleMod','moduleMath'},
     funcOwner = self,
-    callOnActivate = true,
-    activateFunc ='callEditor'
+    tags='basic,counter',
+    activateFunc ='callEditor',
+    visible=true
     }
     enc.call("APIregisterProperty",properties)
     
@@ -105,7 +106,10 @@ function toggleEditor(obj,ply)
 end
 
 function callEditor(t)
-  toggleEditor(t.obj,nil)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
+    toggleEditor(t.obj,nil)
+  end
 end
 
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_11Counter_Addon.lua
+++ b/Encoder/Modules/Encoder_11Counter_Addon.lua
@@ -4,7 +4,7 @@ This module adds only 1/1 Counters
 ]]
 pID = "MTG_11_Counters"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_11Counter_Addon.lua'
-version = '1.4'
+version = '1.5'
 
 function onload()
   self.createButton({
@@ -105,10 +105,10 @@ function toggleEditor(obj,ply)
   end
 end
 
-function callEditor(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
-    toggleEditor(t.obj,nil)
+function callEditor(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+    toggleEditor(obj,nil)
   end
 end
 

--- a/Encoder/Modules/Encoder_Color_Addon.lua
+++ b/Encoder/Modules/Encoder_Color_Addon.lua
@@ -73,10 +73,10 @@ function toggleEditor(obj,ply)
     enc.call("APIrebuildButtons",{obj=obj})
   end
 end
-function callEditor(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
-    toggleEditor(t.obj,nil)
+function callEditor(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+    toggleEditor(obj,nil)
   end
 end
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Color_Addon.lua
+++ b/Encoder/Modules/Encoder_Color_Addon.lua
@@ -4,7 +4,7 @@ This module adds color Designators.
 ]]
 pID = "MTG_Colors"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Color_Addon.lua'
-version = '1.3'
+version = '1.4'
 
 colors={
 w={r=1,g=1,b=1},
@@ -32,7 +32,7 @@ function registerModule(obj,ply)
     name = "MTG Colors",
     values = {'mtg_colors'},
     funcOwner = self,
-    callOnActivate = true,
+    tags='basic,face_prop',
     activateFunc ='callEditor'
     }
     enc.call("APIregisterProperty",properties)
@@ -74,7 +74,10 @@ function toggleEditor(obj,ply)
   end
 end
 function callEditor(t)
-  toggleEditor(t.obj,nil)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
+    toggleEditor(t.obj,nil)
+  end
 end
 function toggleEditClose(obj,ply)
   enc = Global.getVar('Encoder')

--- a/Encoder/Modules/Encoder_CopyFunc_Addon.lua
+++ b/Encoder/Modules/Encoder_CopyFunc_Addon.lua
@@ -5,7 +5,7 @@
 
 pID = "CopyTools"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_CopyFunc_Addon.lua'
-version = '1.3'
+version = '1.4'
 
 function onload()
   self.createButton({
@@ -20,13 +20,15 @@ function registerModule()
   enc = Global.getVar('Encoder')
   if enc ~= nil then
     properties = {
-    toolID = "exactCopy",
+    propID = "exactCopy",
     name = "Exact Copy",
+    values={},
     funcOwner = self,
     activateFunc ='exactCopy',
-    display=true
+    tags="tool",
+    visible=true
     }
-    enc.call("APIregisterTool",properties)   
+    enc.call("APIregisterProperty",properties)   
   end
 end
 

--- a/Encoder/Modules/Encoder_DropOn_Counter.lua
+++ b/Encoder/Modules/Encoder_DropOn_Counter.lua
@@ -16,12 +16,15 @@ function onCollisionEnter(c)
       d = JSON.decode(self.getDescription())
       cd = enc.call('APIobjGetAllData',{obj=obj})
       for k,v in pairs(d) do
+        _,_,action,value = string.find(v,'([%+%-%*%/=])(.*)')
+        _,_,typ,value = string.find(value,'([snbcv]):(.*)')
+        if typ == 'v' then
+          _,_,guid,value = string.find(value,'(.-):(.*)')
+        end
         if enc.call('APIvalueExists',{valueID=k}) then
           if cd[k] == nil then
-            cd[k] = enc.call('APIobjGetValueData',{obj=obj,valueID=k})[k]
+            cd[k] = enc.call("APIobjGetValueData",{obj=obj,valueID=k})[k]
           end
-          _,_,action,value = string.find(v,'([%+%-%*%/=])(.*)')
-          _,_,typ,value = string.find(value,'([snbcv]):(.*)')
           if typ == 'n' then
             value = tonumber(value)
             if action == '+' then
@@ -37,29 +40,63 @@ function onCollisionEnter(c)
             elseif action == '=' then
               cd[k] = value
             else
-              print(action..' is not a recognized operator.')
+              error(action..' is not a recognized operator for value type '..typ..'.')
             end
           elseif typ == 'b' then 
-            cd[k] = value == 'true' and true or false
+            if action == '=' then
+              cd[k] = value == 'true' and true or false
+            else
+              error(action..' is not a recognized operator for value type '..typ..'.')
+            end
           elseif typ == 's' then
             if action == '+' then
               cd[k] = cd[k]..value
             elseif action == '=' then
               cd[k] = value
             else
-              print(action..' is not a recognized operator.')
+              error(action..' is not a recognized operator for value type '..typ..'.')
             end
           elseif typ == 'c' then
             if action == '=' then
               cd[k] = value
             else
-              print(action..' is not a recognized operator.')
+              error(action..' is not a recognized operator for value type '..typ..'.')
             end
           elseif typ == 'v' then
+            if Player[guid] ~= nil then
+              value = enc.call('APIplyGetValueData',{color=guid,valueID=value})
+            else
+              value = enc.call('APIobjGetValueData',{obj=getObjectFromGUID(guid),valueID=value})
+            end
+            if type(value) == 'number' then
+              if action == '+' then
+                cd[k] = cd[k]+value
+              elseif action == '-' then
+                cd[k] = cd[k]-value
+              elseif action == '*' then
+                cd[k] = cd[k]*value
+              elseif action == '/' then
+                if value ~= 0 then
+                  cd[k] = cd[k]/value
+                end
+              elseif action == '=' then
+                cd[k] = value
+              else
+                error(action..' is not a recognized operator for value type '..typ..'.')
+              end
+            elseif type(value) == 'string' then
+              if action == '=' then
+                cd[k] = value
+              else
+                error(action..' is not a recognized operator for value type '..typ..'.')
+              end
+            end
           end
+        else
+          error(value..' is not a recognized value.')
         end
         if enc.call('APIpropertyExists',{propID=k}) then
-          if enc.call('APIobjIsPropEnabled',{obj=obj,propID=k}) ~= v then
+          if enc.call('APIobjIsPropEnabled',{obj=obj,propID=k}) ~= value then
             enc.call('APItoggleProperty',{obj=obj,propID=k})
           end
         end

--- a/Encoder/Modules/Encoder_DropOn_Counter.lua
+++ b/Encoder/Modules/Encoder_DropOn_Counter.lua
@@ -64,7 +64,7 @@ function onCollisionEnter(c)
             end
           elseif typ == 'v' then
             if Player[guid] ~= nil then
-              value = enc.call('APIplyGetValueData',{color=guid,valueID=value})
+              value = enc.call('APIplyGetValueData',{ply=guid,valueID=value})
             else
               value = enc.call('APIobjGetValueData',{obj=getObjectFromGUID(guid),valueID=value})
             end
@@ -96,7 +96,7 @@ function onCollisionEnter(c)
           error(value..' is not a recognized value.')
         end
         if enc.call('APIpropertyExists',{propID=k}) then
-          if enc.call('APIobjIsPropEnabled',{obj=obj,propID=k}) ~= value then
+          if enc.call('APIobjIsPropEnabled',{obj=obj,propID=k}) ~= v then
             enc.call('APItoggleProperty',{obj=obj,propID=k})
           end
         end

--- a/Encoder/Modules/Encoder_Example_Addon.lua
+++ b/Encoder/Modules/Encoder_Example_Addon.lua
@@ -147,11 +147,10 @@ end
 
 --REQUIRED: This is the function specified up in properties.
 --If you specify a function, you must make sure it has the function.
---The function takes a table t={obj=object,player = color}
-function callEditor(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID}) --Toggle prop if this is not a one time use thing.
-  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then --So it does not call the editor on disabling the prop.
-    toggleEditor(t.obj)
+function callEditor(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID}) --Toggle prop if this is not a one time use thing.
+  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then --So it does not call the editor on disabling the prop.
+    toggleEditor(obj)
   end
 end
 function updateModule(wr)

--- a/Encoder/Modules/Encoder_Example_Addon.lua
+++ b/Encoder/Modules/Encoder_Example_Addon.lua
@@ -11,7 +11,7 @@ pID="example_module"
 --URL used for updating the module should you want to include one.
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Example_Addon.lua'
 --Module Version Number
-version = '1.3'
+version = '1.4'
 
 
 --Recommended
@@ -39,7 +39,7 @@ function registerModule()
     values = {'example1','example2'} --The values you will be sending and requesting with APIobjGetValues APIobjSetValues
     funcOwner = self, --Who owns the triggering function. Generally will be self,
 											--but you could make it target other objects.
-    callOnActivate = true, --Should the activated func call when the player presses the api button?
+    tags="list,of,tags", --Used by menus to decide if this belongs in it.
     activateFunc ='callEditor' --The function that should be called in the funcOwner.
     }
 		--Time to register the property. You can register multiple properties from one module.
@@ -149,7 +149,10 @@ end
 --If you specify a function, you must make sure it has the function.
 --The function takes a table t={obj=object,player = color}
 function callEditor(t)
-  toggleEditor(t.obj)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID}) --Toggle prop if this is not a one time use thing.
+  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then --So it does not call the editor on disabling the prop.
+    toggleEditor(t.obj)
+  end
 end
 function updateModule(wr)
   enc = Global.getVar('Encoder')

--- a/Encoder/Modules/Encoder_Keyword_Modules.lua
+++ b/Encoder/Modules/Encoder_Keyword_Modules.lua
@@ -4,7 +4,7 @@ This module adds keyword abilities.
 ]]
 pID = "MTG_Keyword_Abilites"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Keyword_Modules.lua'
-version = '1.6'
+version = '1.7'
 KeywordList={
   mtg_tramplecounter={name="Trample",des=":This creature can deal excess combat damage to player or planeswalker it's attacking.",val='number',def=0},
   mtg_firststrikecounter={name="First Strike",des=":This creature deals combat damage before creatures without first strike.",val='number',def=0},
@@ -45,7 +45,7 @@ function registerModule(obj,ply)
     name = "Keyword Abilities",
     values = values,
     funcOwner = self,
-    callOnActivate = true,
+    tags="basic,counter",
     activateFunc ='callEditor'
     }
     enc.call("APIregisterProperty",properties)
@@ -102,7 +102,10 @@ function toggleEditor(obj,ply)
   end
 end
 function callEditor(t)
-  toggleEditor(t.obj,nil)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
+    toggleEditor(t.obj,nil)
+  end
 end
 function toggleEditClose(obj,ply)
   enc = Global.getVar('Encoder')

--- a/Encoder/Modules/Encoder_Keyword_Modules.lua
+++ b/Encoder/Modules/Encoder_Keyword_Modules.lua
@@ -101,10 +101,10 @@ function toggleEditor(obj,ply)
     enc.call("APIrebuildButtons",{obj=obj})
   end
 end
-function callEditor(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
-    toggleEditor(t.obj,nil)
+function callEditor(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+    toggleEditor(obj,nil)
   end
 end
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Loyalty_Addon.lua
+++ b/Encoder/Modules/Encoder_Loyalty_Addon.lua
@@ -4,7 +4,7 @@ This module adds only Loyalty Counters.
 ]]
 pID = "MTG_Loyalty"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Loyalty_Addon.lua'
-version = '1.3'
+version = '1.5'
 
 
 function onload()
@@ -25,7 +25,7 @@ function registerModule()
     name = "Loyalty",
     values = {'loyaltyCounter','moduleMod','moduleMath'},
     funcOwner = self,
-    callOnActivate = true,
+    tags="basic,counter",
     activateFunc ='callEditor'
     }
     enc.call("APIregisterProperty",properties)
@@ -104,7 +104,10 @@ function toggleEditor(obj,ply)
 end
 
 function callEditor(t)
-  toggleEditor(t.obj,nil)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
+    toggleEditor(t.obj,nil)
+  end
 end
 
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Loyalty_Addon.lua
+++ b/Encoder/Modules/Encoder_Loyalty_Addon.lua
@@ -103,10 +103,10 @@ function toggleEditor(obj,ply)
   end
 end
 
-function callEditor(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
-    toggleEditor(t.obj,nil)
+function callEditor(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+    toggleEditor(obj,nil)
   end
 end
 

--- a/Encoder/Modules/Encoder_Menu_Default.lua
+++ b/Encoder/Modules/Encoder_Menu_Default.lua
@@ -1,0 +1,183 @@
+--[[Basic Menu
+by Tipsy Hobbit//STEAM_0:1:13465982
+The basic menu style, default for the encoder.
+If no menu has been registered, then the encoder will spawn this from the github.
+]]
+pID="Default_Menu"
+UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Menu_Default.lua'
+version = '1.0'
+function onload()
+  Wait.condition(registerModule,function() return Global.getVar('Encoder') ~= nil and true or false end)
+end
+function registerModule()
+  enc = Global.getVar('Encoder')
+  if enc ~= nil then
+    menu={
+      styleID=pID,
+      funcOwner=self
+    }
+    enc.call("APIregisterMenu",menu)
+  end
+end
+function createMenu(t)
+  local o = t.obj
+  local p = t.ply
+  if type(o) == 'String' and Players[o] ~= nil then
+    for k,v in pairs(Players[o].encoded) do
+      if v == true and Properties[k]~=nil and Properties[k].funcOwner~= nil then
+        Properties[k].funcOwner.call("createButtons",{ply=o,obj=Players[o].token})
+      end
+    end
+  else
+    o.clearButtons()
+    o.clearInputs()
+    if EncodedObjects[o.getGUID()].disable ~= true then
+      local flip = EncodedObjects[o.getGUID()].flip
+      local scaler = {x=1,y=1,z=1}--o.getScale()
+      zpos = 0.28*flip*scaler.z
+      if EncodedObjects[o.getGUID()].editing == nil then
+        if EncodedObjects[o.getGUID()].menus.copy.open == false then
+          o.createButton({
+          label=">\n>\n>", click_function='toggleCopyMenu', function_owner=self,
+          position={1*flip*scaler.x,zpos,-0.7*scaler.y}, height=250, width=10, font_size=60,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1},tooltip="Tool Menu"
+          })
+        else
+          o.createButton({
+          label="<\n<\n<", click_function='toggleCopyMenu', function_owner=self,
+          position={1*flip*scaler.x,zpos,-0.7*scaler.y}, height=250, width=10, font_size=60,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1},tooltip="Tool Menu"
+          })
+          temp = "Disable Encoding"
+          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,-1,0)
+          o.createButton({
+          label=temp, click_function='disableEncoding', function_owner=self,
+          position={(1.05+offset_x)*flip*scaler.x,zpos,(1.5+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,0,0,1}
+          })
+          temp = "↿     ↾"
+          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,-1,0)
+          o.createButton({
+          label=temp, click_function='CMscrollUp', function_owner=self,
+          position={(1.05+offset_x)*flip*scaler.x,zpos,(-1+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
+          })
+          temp = "⇃     ⇂"
+          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,-1,0)
+          o.createButton({
+          label=temp, click_function='CMscrollDown', function_owner=self,
+          position={(1.05+offset_x)*flip*scaler.x,zpos,1*scaler.y}, height=100, width=barSize, font_size=fsize,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
+          })
+          local count = 0
+          local pos = EncodedObjects[o.getGUID()].menus.copy.pos
+          for k,v in pairsByKeys(Tools) do
+            if v.display==true and v.funcOwner ~= nil then
+              if pos <= count and count < pos+7 then
+                temp = v.name
+                barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,-1,0)
+                o.createButton({
+                label=temp, click_function=v.activateFunc, function_owner=v.funcOwner,
+                position={(1.05+offset_x)*flip*scaler.x,zpos,(-0.75+((count-pos)/3)+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
+                rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
+                })
+              end
+              count = count+1
+            end
+          end
+        end
+        if EncodedObjects[o.getGUID()].menus.props.open == false then
+          o.createButton({
+          label="<\n<\n<", click_function='togglePropMenu', function_owner=self,
+          position={-1.0*flip*scaler.x,zpos,-0.7*scaler.y}, height=250, width=10, font_size=60,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1},tooltip="Module Menu"
+          })
+        else
+          o.createButton({
+          label=">\n>\n>", click_function='togglePropMenu', function_owner=self,
+          position={-1.0*flip*scaler.x,zpos,-0.7*scaler.y}, height=250, width=10, font_size=60,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1},tooltip="Module Menu"
+          })
+          temp = " Flip "
+          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,1,0)
+          o.createButton({
+          label=temp, click_function='flipMenu', function_owner=self,
+          position={(-1.05+offset_x)*flip*scaler.x,zpos,(1.25+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
+          })
+          temp = "↿     ↾"
+          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,1,0)
+          o.createButton({
+          label=temp, click_function='PMscrollUp', function_owner=self,
+          position={(-1.05+offset_x)*flip*scaler.x,zpos,(-1+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
+          })
+          temp = "⇃     ⇂"
+          barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,1,0)
+          o.createButton({
+          label=temp, click_function='PMscrollDown', function_owner=self,
+          position={(-1.05+offset_x)*flip*scaler.x,zpos,(1+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
+          rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
+          })
+          
+          local count = 0
+          local pos = EncodedObjects[o.getGUID()].menus.props.pos
+          for k,v in pairsByKeys(Properties) do
+            if v.funcOwner ~= nil and v.visible ~= false then
+              if pos <= count and count < pos+7 then
+                temp = v.name
+                barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,1,0)
+                o.createButton({
+                label=temp, click_function=v.propID..'Toggle', function_owner=self,
+                position={(-1.05+offset_x)*flip*scaler.x,zpos,(-0.75+((count-pos)/3.9)+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
+                rotation={0,0,90-90*flip},color={0,0,0,1},font_color={1,1,1,1}
+                })
+              end
+              count = count+1
+            end
+          end
+        end
+        
+        for k,v in pairs(EncodedObjects[o.getGUID()].encoded) do
+          if v == true and Properties[k]~=nil and Properties[k].funcOwner~= nil then
+            --print(k)
+            Properties[k].funcOwner.call("createButtons",{obj=o})
+          end
+        end
+      else
+        k = EncodedObjects[o.getGUID()].editing
+        if Properties[k]~=nil and Properties[k].funcOwner~= nil then
+          Properties[k].funcOwner.call("createButtons",{obj=o})
+        end
+        temp = " X "
+        barSize,fsize,offset_x,offset_y = updateSize(temp,90,90,0,0)
+        o.createButton({
+        label=temp, click_function='closeEditor', function_owner=self,
+        position={(-1.1+offset_x)*flip,zpos,(1.4+offset_y)}, height=100, width=barSize, font_size=fsize,
+        rotation={0,0,90-90*flip}
+        })
+      end
+    end
+  end
+end
+end
+
+function updateModule(wr)
+  enc = Global.getVar('Encoder')
+  if enc ~= nil then
+    wr = wr.text
+    wrv = string.match(wr,"version = '(.-)'")
+    if wrv == 'DEPRECIATED' then
+      enc.call("APIremoveProperty",{propID=pID})
+      self.destruct()
+    end
+    local ver = enc.call("APIversionComp",{wv=wrv,cv=version})
+    if ''..ver ~= ''..version then
+      broadcastToAll("An update has been found for "..pID..". Reloading Module.")
+      self.script_code = wr
+      self.reload()
+    else
+      broadcastToAll("No update found for "..pID..". Carry on.")
+    end
+  end
+end

--- a/Encoder/Modules/Encoder_Menu_Default.lua
+++ b/Encoder/Modules/Encoder_Menu_Default.lua
@@ -5,7 +5,7 @@ If no menu has been registered, then the encoder will spawn this from the github
 ]]
 pID="Default_Menu"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Menu_Default.lua'
-version = '1.1'
+version = '1.2'
 Style = {}
 function onload()
   Wait.condition(registerModule,function() return Global.getVar('Encoder') ~= nil and true or false end)
@@ -156,7 +156,7 @@ function createPropMenu(t)
             temp = v.name
             barSize,fsize,offset_x,offset_y = enc.call('APIformatButton',{str=temp,font_size=90,max_len=90,xJust=1,yJust=0})
             o.createButton(Style.new{
-            label=temp, click_function=v.propID..'Toggle', function_owner=self,
+            label=temp, click_function=v.activateFunc, function_owner=v.funcOwner,
             position={(-1.05+offset_x)*flip*scaler.x,zpos,(-0.75+((count-md.pos)/3.9)+offset_y)*scaler.y}, height=100, width=barSize, font_size=fsize,
             rotation={0,0,90-90*flip}
             })

--- a/Encoder/Modules/Encoder_Moprh_Addon.lua
+++ b/Encoder/Modules/Encoder_Moprh_Addon.lua
@@ -2,7 +2,7 @@
 --By Tipsy Hobbit
 pID = "MTG_Morph"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Moprh_Addon.lua'
-version = '1.7'
+version = '1.8'
 
 function onload()
   self.createButton({
@@ -25,7 +25,7 @@ function registerModule()
 		name = "Morph",
 		values = {'mtg_morphed'},
 		funcOwner = self,
-		callOnActivate = true,
+		tags="basic,face_prop",
 		activateFunc ='toggleMorph'
 		}
 		enc.call("APIregisterProperty",properties)
@@ -59,6 +59,7 @@ function createButtons(t)
 end
 
 function toggleMorph(t)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
   tMorph(t.obj,t.ply)
 end
 

--- a/Encoder/Modules/Encoder_Moprh_Addon.lua
+++ b/Encoder/Modules/Encoder_Moprh_Addon.lua
@@ -58,9 +58,9 @@ function createButtons(t)
   end
 end
 
-function toggleMorph(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
-  tMorph(t.obj,t.ply)
+function toggleMorph(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID})
+  tMorph(obj,ply)
 end
 
 function tMorph(obj,ply)

--- a/Encoder/Modules/Encoder_NotePad_Addon.lua
+++ b/Encoder/Modules/Encoder_NotePad_Addon.lua
@@ -2,7 +2,7 @@
 --by Tipsy Hobbit//STEAM_0:1:13465982
 pID = "notepad"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_NotePad_Addon.lua'
-version = '1.4'
+version = '1.5'
 
 function onload()
   self.createButton({
@@ -22,8 +22,8 @@ function registerModule()
 		name = "Notepad",
 		values = {'notes'},
 		funcOwner = self,
-		callOnActivate = false,
-		activateFunc =''
+		tags='tool',
+		activateFunc ='toggleProp'
 		}
 		enc.call("APIregisterProperty",properties)
     value = {
@@ -34,6 +34,10 @@ function registerModule()
     }
     enc.call("APIregisterValue",value)
   end
+end
+
+function toggleProp(t)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
 end
 
 function createButtons(t)

--- a/Encoder/Modules/Encoder_NotePad_Addon.lua
+++ b/Encoder/Modules/Encoder_NotePad_Addon.lua
@@ -36,8 +36,8 @@ function registerModule()
   end
 end
 
-function toggleProp(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
+function toggleProp(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID})
 end
 
 function createButtons(t)

--- a/Encoder/Modules/Encoder_Phasing_Addon.lua
+++ b/Encoder/Modules/Encoder_Phasing_Addon.lua
@@ -2,7 +2,7 @@
 --By Tipsy Hobbit
 pID = "MTG_Phase"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Phasing_Addon.lua'
-version = '1.8'
+version = '1.9'
 
 function onload()
   self.createButton({
@@ -20,7 +20,7 @@ function registerModule()
 		name = "Phase Out",
 		values = {'mtg_phased'},
 		funcOwner = self,
-		callOnActivate = true,
+		tags='tool,face_prop',
 		activateFunc ='phaseOut'
 		}
 		enc.call("APIregisterProperty",properties)
@@ -50,6 +50,7 @@ end
 function phaseOut(t)
   enc = Global.getVar('Encoder')
   if enc ~= nil then
+    enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
     data = enc.call("APIobjGetPropData",{obj=t.obj,propID=pID})
 		if data.mtg_phased ~= true then
 			data.mtg_phased = true

--- a/Encoder/Modules/Encoder_Phasing_Addon.lua
+++ b/Encoder/Modules/Encoder_Phasing_Addon.lua
@@ -47,17 +47,17 @@ function createButtons(t)
     })
   end
 end
-function phaseOut(t)
+function phaseOut(obj,ply)
   enc = Global.getVar('Encoder')
   if enc ~= nil then
-    enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
-    data = enc.call("APIobjGetPropData",{obj=t.obj,propID=pID})
+    enc.call("APItoggleProperty",{obj=obj,propID=pID})
+    data = enc.call("APIobjGetPropData",{obj=obj,propID=pID})
 		if data.mtg_phased ~= true then
 			data.mtg_phased = true
     else
       data.mtg_phased = false
     end
-    enc.call("APIobjSetPropData",{obj=t.obj,propID=pID,data=data})
+    enc.call("APIobjSetPropData",{obj=obj,propID=pID,data=data})
   end
 end
 function unPhased(obj,ply)

--- a/Encoder/Modules/Encoder_PowerToughness_Addon.lua
+++ b/Encoder/Modules/Encoder_PowerToughness_Addon.lua
@@ -121,10 +121,10 @@ function toggleEditor(obj,ply)
   end
 end
 
-function callEditor(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
-    toggleEditor(t.obj,nil)
+function callEditor(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+    toggleEditor(obj,nil)
   end
 end
 

--- a/Encoder/Modules/Encoder_PowerToughness_Addon.lua
+++ b/Encoder/Modules/Encoder_PowerToughness_Addon.lua
@@ -3,7 +3,7 @@ by Tipsy Hobbit//STEAM_0:1:13465982
 This module adds only 1/1 Counters
 ]]
 pID = "MTG_Power_Toughness"
-version = '1.1'
+version = '1.2'
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_PowerToughness_Addon.lua'
 
 
@@ -23,7 +23,7 @@ function registerModule()
     name = "Power/Toughness",
     values = {'power_base','toughness_base','moduleMod','moduleMath'},
     funcOwner = self,
-    callOnActivate = true,
+    tags="base_stat,basic",
     activateFunc ='callEditor'
     }
     enc.call("APIregisterProperty",properties)
@@ -122,7 +122,10 @@ function toggleEditor(obj,ply)
 end
 
 function callEditor(t)
-  toggleEditor(t.obj,nil)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
+    toggleEditor(t.obj,nil)
+  end
 end
 
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Status_Effects_Addon.lua
+++ b/Encoder/Modules/Encoder_Status_Effects_Addon.lua
@@ -4,7 +4,7 @@ This module adds only Status Effects.
 ]]
 pID = "MTG_Status_Effects"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Status_Effects_Addon.lua'
-version = '1.3'
+version = '1.4'
 
 StatusList={
   mtg_exert={name="Exerted", des=":Card does not untap the next Controller's untap step.",val='boolean',def=false},
@@ -36,7 +36,7 @@ function registerModule(obj,ply)
     name = "Status Effects",
     values = values,
     funcOwner = self,
-    callOnActivate = true,
+    tags="basic,face_prop",
     activateFunc ='callEditor'
     }
     enc.call("APIregisterProperty",properties)
@@ -84,7 +84,10 @@ function toggleEditor(obj,ply)
   end
 end
 function callEditor(t)
-  toggleEditor(t.obj,nil)
+  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
+    toggleEditor(t.obj,nil)
+  end
 end
 function toggleEditClose(obj,ply)
   enc = Global.getVar('Encoder')

--- a/Encoder/Modules/Encoder_Status_Effects_Addon.lua
+++ b/Encoder/Modules/Encoder_Status_Effects_Addon.lua
@@ -83,10 +83,10 @@ function toggleEditor(obj,ply)
     enc.call("APIrebuildButtons",{obj=obj})
   end
 end
-function callEditor(t)
-  enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=t.obj,propID=pID}) then
-    toggleEditor(t.obj,nil)
+function callEditor(obj,ply)
+  enc.call("APItoggleProperty",{obj=obj,propID=pID})
+  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+    toggleEditor(obj,nil)
   end
 end
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Style_Default.lua
+++ b/Encoder/Modules/Encoder_Style_Default.lua
@@ -2,7 +2,7 @@
 by Tipsy Hobbit//STEAM_0:1:13465982
 A simple double button style.
 ]]
-pID="Default_Style"
+pID="Basic_Style"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Style_Default.lua'
 version = '1.0'
 
@@ -10,43 +10,37 @@ function onload()
   Wait.condition(registerModule,function() return Global.getVar('Encoder') ~= nil and true or false end)
 end
 
+default = {
+  click_function=nil, --Not optional, must be passed in by the originating module.
+  function_owner=nil, --Not optional
+  label='',
+  position={0,0.28,0},
+  rotation={0,0,0},
+  scale={1,1,1},
+  width=60,
+  height=60,
+  font_size=10,
+  color= {0,0,0,1},
+  font_color= {1,1,1,1},
+  hover_color= {0.3,0.3,0.3,1},
+  press_color= {0.6,0.6,0.6,1},
+  tooltip=""
+}
+
 function registerModule()
   enc = Global.getVar('Encoder')
   if enc ~= nil then
     style={
       styleID=pID,
-      funcOwner=self
+      name = '',
+      desc = '',
+      styleTable=JSON.encode(default)
     }
     enc.call("APIregisterStyle",style)
   end
 end
 
-default = {
-  click_function=nil --Not optional, must be passed in by the originating module.
-  function_owner=nil --Not optional
-  label=''
-  position={0,0.28,0}
-  rotation={0,0,0}
-  scale={1,1,1}
-  width=60
-  height=60
-  font_size=10
-  color= {0,0,0,1}
-  font_color= {1,1,1,1}
-  hover_color= {0.3,0.3,0.3,1}
-  press_color= {0.6,0.6,0.6,1}
-  tooltip="Style Test"
-}
 
-function createStyleButton(t)
-  enc = Global.getVar('Encoder')
-  if enc ~= nil then
-    for k,v in pairs(default) do
-      t = t[k] ~= nil and t[k] or v
-    end
-    t.obj.createButton(t)
-  end
-end
 
 function updateModule(wr)
   enc = Global.getVar('Encoder')

--- a/Encoder/Modules/Encoder_Style_Default.lua
+++ b/Encoder/Modules/Encoder_Style_Default.lua
@@ -1,0 +1,69 @@
+--[[Simple Style
+by Tipsy Hobbit//STEAM_0:1:13465982
+A simple double button style.
+]]
+pID="Default_Style"
+UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Style_Default.lua'
+version = '1.0'
+
+function onload()
+  Wait.condition(registerModule,function() return Global.getVar('Encoder') ~= nil and true or false end)
+end
+
+function registerModule()
+  enc = Global.getVar('Encoder')
+  if enc ~= nil then
+    style={
+      styleID=pID,
+      funcOwner=self
+    }
+    enc.call("APIregisterStyle",style)
+  end
+end
+
+default = {
+  click_function=nil --Not optional, must be passed in by the originating module.
+  function_owner=nil --Not optional
+  label=''
+  position={0,0.28,0}
+  rotation={0,0,0}
+  scale={1,1,1}
+  width=60
+  height=60
+  font_size=10
+  color= {0,0,0,1}
+  font_color= {1,1,1,1}
+  hover_color= {0.3,0.3,0.3,1}
+  press_color= {0.6,0.6,0.6,1}
+  tooltip="Style Test"
+}
+
+function createStyleButton(t)
+  enc = Global.getVar('Encoder')
+  if enc ~= nil then
+    for k,v in pairs(default) do
+      t = t[k] ~= nil and t[k] or v
+    end
+    t.obj.createButton(t)
+  end
+end
+
+function updateModule(wr)
+  enc = Global.getVar('Encoder')
+  if enc ~= nil then
+    wr = wr.text
+    wrv = string.match(wr,"version = '(.-)'")
+    if wrv == 'DEPRECIATED' then
+      enc.call("APIremoveProperty",{propID=pID})
+      self.destruct()
+    end
+    local ver = enc.call("APIversionComp",{wv=wrv,cv=version})
+    if ''..ver ~= ''..version then
+      broadcastToAll("An update has been found for "..pID..". Reloading Module.")
+      self.script_code = wr
+      self.reload()
+    else
+      broadcastToAll("No update found for "..pID..". Carry on.")
+    end
+  end
+end

--- a/Encoder/Modules/Encoder_Token_Addon.lua
+++ b/Encoder/Modules/Encoder_Token_Addon.lua
@@ -2,7 +2,7 @@
 --By Tipsy Hobbit
 pID = "MTG_Token"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Token_Addon.lua'
-version = '1.3'
+version = '1.4'
 
 function onload()
   self.createButton({
@@ -20,7 +20,7 @@ function registerModule()
     name = "Is Token",
     values = {'mtg_token'},
     funcOwner = self,
-    callOnActivate = false,
+    tags='tool',
     activateFunc ='tToken'
     }
     enc.call("APIregisterProperty",properties)
@@ -49,9 +49,10 @@ function createButtons(t)
   end
 end
 
-function tToken(t)
+function tToken(obj,ply)
   enc = Global.getVar('Encoder')
   if enc ~= nil then
+    enc.call("APItoggleProperty",{obj=t.obj,propID=pID})
     data = enc.call("APIobjGetPropData",{obj=t.obj,propID=pID})
     if data.mtg_token ~= true then
       data.mtg_token = true

--- a/Encoder/Modules/Encoder_autoencode_Addon.lua
+++ b/Encoder/Modules/Encoder_autoencode_Addon.lua
@@ -5,7 +5,7 @@
 
 pID = "AutoEncoder"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_autoencode_Addon.lua'
-version = '1.3'
+version = '1.4'
 
 function onload()
   self.createButton({
@@ -20,13 +20,15 @@ function registerModule()
   enc = Global.getVar('Encoder')
   if enc ~= nil then
     properties = {
-    toolID = pID,
+    propID = pID,
     name = "Auto Encoder",
+    values={},
     funcOwner = self,
     activateFunc ='',
-    display=false
+    tags="tool",
+    visible=false
     }
-    enc.call("APIregisterTool",properties)
+    enc.call("APIregisterProperty",properties)
   end
 end
 

--- a/Encoder/Tools/MODULE_DEBUGER.lua
+++ b/Encoder/Tools/MODULE_DEBUGER.lua
@@ -35,14 +35,19 @@ function onObjectHover(ply,obj)
   if enc ~= nil and obj~=nil then
     if enc.call("APIobjectExists",{obj=obj}) then
       data = enc.call("APIobjGetAllData",{obj=obj})
+      for k,v in pairs(enc.call('APIlistMenus')) do
+        table.insert(data,enc.call("APIobjGetMenuData",{obj=obj,menuID=v}))
+      end
       UI.setAttribute(MPID..ply.."Text","text",printOutData(data))
       UI.show(MPID..ply.."Display")
     end
     if obj.getVar("pID") ~= nil then
       data = enc.getTable("Properties")
-      data = data[obj.getVar("pID")]
-      UI.setAttribute(MPID..ply.."Text","text",printOutData(data))
-      UI.show(MPID..ply.."Display")
+      if data[obj.getVar("pID")] ~= nil then
+        data = data[obj.getVar("pID")]
+        UI.setAttribute(MPID..ply.."Text","text",printOutData(data))
+        UI.show(MPID..ply.."Display")
+      end
     end
   else
     UI.hide(MPID..ply.."Display")


### PR DESCRIPTION
Big update:

When updating to this version and beyond, if there is no menu module present, the encoder will spawn a basic menu module.

Players[color] can now be encoded and accessed much like objects can.
Menus are now a separate item, allowing for customization of button placement, style, and what it contains.
Styles are a default button table that one can register and set to the global style, changing how all buttons that call on it look.

Tools no longer exist as a module type, instead Properties now have a tags="string,string" parameter. Menus can use this when looking for properties that should show up in them.
The callOnActivate function is no more, and activateFunc is now required.

`function activateFuncExample(obj,ply)
  enc.call("APItoggleProperty",{obj=obj,propID=pID}) --Do you want this property to toggle on and off or just activate once per click.
  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
    --this will only be called on toggling to true.
  end
end`

Better tracking of objects entering hands.
