### PR TITLE
Function and Module update.

### DIFF
--- a/Encoder/Encoder Core.lua
+++ b/Encoder/Encoder Core.lua
@@ -1,7 +1,7 @@
 --By Tipsy Hobbit
 mod_name = "Encoder"
 postfix = ''
-version = '4.5.3'
+version = '4.5.4'
 version_string = "Updated to fix small bug with latest TTS version."
 change_log = [[Updated .tag to .type .
 ]]
@@ -1160,6 +1160,16 @@ function APIobjSetProps(p)
   if EncodedObjects[target] ~= nil then
     EncodedObjects[target].encoded = p.data
   end
+end
+--Call target properties activateFunc: {obj=obj,propID=propID,color=player.color,data=alt_click}
+function APIobjCallProp(p)
+  local target = p.obj.getGUID()
+  if EncodedObjects[target] ~= nil then
+    local prop = Properties[p.propID]
+    if prop ~= nil then
+      prop.funcOwner.call(prop.activateFunc,{p.obj,p.color or nil,p.data or false})
+    end
+  end 
 end
 --Enable target prop: {obj=obj,propID=propID}
 function APIobjEnableProp(p)

--- a/Encoder/Modules/Encoder_Color_Addon.lua
+++ b/Encoder/Modules/Encoder_Color_Addon.lua
@@ -4,7 +4,7 @@ This module adds color Designators.
 ]]
 pID = "MTG_Colors"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Color_Addon.lua'
-version = '1.5.3'
+version = '1.12'
 Style = {}
 colors={
 w={c=Color(0.988,0.988,0.757),n="White"},
@@ -92,12 +92,17 @@ function toggleEditor(obj,ply)
     enc.call("APIrebuildButtons",{obj=obj})
   end
 end
-function callEditor(obj,ply)
-  enc.call("APItoggleProperty",{obj=obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
-    toggleEditor(obj,nil)
+function callEditor(obj,ply,alt)
+  if type(obj) == 'Table' then obj=obj[1] ply=obj[2] alt=obj[3] end
+  if alt then
+    enc.call("APIobjResetProp",{obj=obj,propID=pID})
   else
-    enc.call("APIrebuildButtons",{obj=obj})
+    enc.call("APItoggleProperty",{obj=obj,propID=pID})
+    if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+      toggleEditor(obj,nil)
+    else
+      enc.call("APIrebuildButtons",{obj=obj})
+    end
   end
 end
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Keyword_Modules.lua
+++ b/Encoder/Modules/Encoder_Keyword_Modules.lua
@@ -4,7 +4,7 @@ This module adds keyword abilities.
 ]]
 pID = "MTG_Keyword_Abilites"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Keyword_Modules.lua'
-version = '1.7.4'
+version = '1.12'
 KeywordList={
   mtg_trample_counter={name="Trample",des=":This creature can deal excess combat damage to player or planeswalker it's attacking.",val='number',def=0},
   mtg_firststrike_counter={name="First Strike",des=":This creature deals combat damage before creatures without first strike.",val='number',def=0},
@@ -110,12 +110,17 @@ function toggleEditor(obj,ply)
     enc.call("APIrebuildButtons",{obj=obj})
   end
 end
-function callEditor(obj,ply)
-  enc.call("APItoggleProperty",{obj=obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
-    toggleEditor(obj,nil)
+function callEditor(obj,ply,alt)
+  if type(obj) == 'Table' then obj=obj[1] ply=obj[2] alt=obj[3] end
+  if alt then
+    enc.call("APIobjResetProp",{obj=obj,propID=pID})
   else
-    enc.call("APIrebuildButtons",{obj=obj})
+    enc.call("APItoggleProperty",{obj=obj,propID=pID})
+    if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+      toggleEditor(obj,nil)
+    else
+      enc.call("APIrebuildButtons",{obj=obj})
+    end
   end
 end
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Loyalty_Addon.lua
+++ b/Encoder/Modules/Encoder_Loyalty_Addon.lua
@@ -4,7 +4,7 @@ This module adds only Loyalty Counters.
 ]]
 pID = "MTG_Loyalty"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Loyalty_Addon.lua'
-version = '1.5.5'
+version = '1.12'
 Style={}
 
 function onload()
@@ -112,12 +112,17 @@ function toggleEditor(obj,ply)
   end
 end
 
-function callEditor(obj,ply)
-  enc.call("APItoggleProperty",{obj=obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
-    toggleEditor(obj,nil)
+function callEditor(obj,ply,alt)
+  if type(obj) == 'Table' then obj=obj[1] ply=obj[2] alt=obj[3] end
+  if alt then
+    enc.call("APIobjResetProp",{obj=obj,propID=pID})
   else
-    enc.call("APIrebuildButtons",{obj=obj})
+    enc.call("APItoggleProperty",{obj=obj,propID=pID})
+    if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+      toggleEditor(obj,nil)
+    else
+      enc.call("APIrebuildButtons",{obj=obj})
+    end
   end
 end
 

--- a/Encoder/Modules/Encoder_Moprh_Addon.lua
+++ b/Encoder/Modules/Encoder_Moprh_Addon.lua
@@ -2,7 +2,7 @@
 --By Tipsy Hobbit
 pID = "MTG_Morph"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Moprh_Addon.lua'
-version = '1.11'
+version = '1.12'
 
 function onload()
   self.createButton({
@@ -58,7 +58,8 @@ function createButtons(t)
   end
 end
 
-function toggleMorph(obj,ply)
+function toggleMorph(obj,ply,alt)
+  if type(obj) == 'Table' then obj=obj[1] ply=obj[2] alt=obj[3] end
   enc.call("APItoggleProperty",{obj=obj,propID=pID})
   tMorph(obj,ply)
 end

--- a/Encoder/Modules/Encoder_NotePad_Addon.lua
+++ b/Encoder/Modules/Encoder_NotePad_Addon.lua
@@ -2,7 +2,7 @@
 --by Tipsy Hobbit//STEAM_0:1:13465982
 pID = "notepad"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_NotePad_Addon.lua'
-version = '1.6'
+version = '1.12'
 
 function onload()
   self.createButton({
@@ -36,9 +36,14 @@ function registerModule()
   end
 end
 
-function toggleProp(obj,ply)
-  enc.call("APItoggleProperty",{obj=obj,propID=pID})
-  enc.call("APIrebuildButtons",{obj=obj})
+function toggleProp(obj,ply,alt)
+  if type(obj) == 'Table' then obj=obj[1] ply=obj[2] alt=obj[3] end
+  if alt then
+    enc.call("APIobjResetProp",{obj=obj,propID=pID})
+  else
+    enc.call("APItoggleProperty",{obj=obj,propID=pID})
+    enc.call("APIrebuildButtons",{obj=obj})
+  end
 end
 
 function createButtons(t)

--- a/Encoder/Modules/Encoder_Phasing_Addon.lua
+++ b/Encoder/Modules/Encoder_Phasing_Addon.lua
@@ -2,7 +2,7 @@
 --By Tipsy Hobbit
 pID = "MTG_Phase"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Phasing_Addon.lua'
-version = '1.10'
+version = '1.12'
 
 function onload()
   self.createButton({

--- a/Encoder/Modules/Encoder_PowerToughness_Addon.lua
+++ b/Encoder/Modules/Encoder_PowerToughness_Addon.lua
@@ -3,7 +3,7 @@ by Tipsy Hobbit//STEAM_0:1:13465982
 This module adds only 1/1 Counters
 ]]
 pID = "MTG_Power_Toughness"
-version = '1.2.4'
+version = '1.12'
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_PowerToughness_Addon.lua'
 Style={}
 
@@ -194,12 +194,17 @@ function toggleEditor(obj,ply)
     enc.call("APIrebuildButtons",{obj=obj})
   end
 end
-function callEditor(obj,ply)
-  enc.call("APItoggleProperty",{obj=obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
-    toggleEditor(obj,nil)
+function callEditor(obj,ply,alt)
+  if type(obj) == 'Table' then obj=obj[1] ply=obj[2] alt=obj[3] end
+  if alt then
+    enc.call("APIobjResetProp",{obj=obj,propID=pID})
   else
-    enc.call("APIrebuildButtons",{obj=obj})
+    enc.call("APItoggleProperty",{obj=obj,propID=pID})
+    if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+      toggleEditor(obj,nil)
+    else
+      enc.call("APIrebuildButtons",{obj=obj})
+    end
   end
 end
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Status_Effects_Addon.lua
+++ b/Encoder/Modules/Encoder_Status_Effects_Addon.lua
@@ -4,7 +4,7 @@ This module adds only Status Effects.
 ]]
 pID = "MTG_Status_Effects"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Status_Effects_Addon.lua'
-version = '1.4.2'
+version = '1.12'
 
 StatusList={
   mtg_exert={name="Exerted", des=":Card does not untap the next Controller's untap step.",val='boolean',def=false},
@@ -83,12 +83,17 @@ function toggleEditor(obj,ply)
     enc.call("APIrebuildButtons",{obj=obj})
   end
 end
-function callEditor(obj,ply)
-  enc.call("APItoggleProperty",{obj=obj,propID=pID})
-  if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
-    toggleEditor(obj,nil)
+function callEditor(obj,ply,alt)
+  if type(obj) == 'Table' then obj=obj[1] ply=obj[2] alt=obj[3] end
+  if alt then
+    enc.call("APIobjResetProp",{obj=obj,propID=pID})
   else
-    enc.call("APIrebuildButtons",{obj=obj})
+    enc.call("APItoggleProperty",{obj=obj,propID=pID})
+    if enc.call("APIobjIsPropEnabled",{obj=obj,propID=pID}) then
+      toggleEditor(obj,nil)
+    else
+      enc.call("APIrebuildButtons",{obj=obj})
+    end
   end
 end
 function toggleEditClose(obj,ply)

--- a/Encoder/Modules/Encoder_Token_Addon.lua
+++ b/Encoder/Modules/Encoder_Token_Addon.lua
@@ -2,7 +2,7 @@
 --By Tipsy Hobbit
 pID = "MTG_Token"
 UPDATE_URL='https://raw.githubusercontent.com/Jophire/Tabletop-Simulator-Workshop-Items/master/Encoder/Modules/Encoder_Token_Addon.lua'
-version = '1.7.1'
+version = '1.12'
 Style={}
 
 function onload()
@@ -61,7 +61,7 @@ function createButtons(t)
   end
 end
 
-function tToken(obj,ply)
+function tToken(obj,ply,alt)
   enc = Global.getVar('Encoder')
   if enc ~= nil then
     enc.call("APItoggleProperty",{obj=obj,propID=pID})
@@ -71,6 +71,7 @@ function tToken(obj,ply)
     else
       data.mtg_token = false
     end
+    enc.call("APIobjSetPropData",{obj=obj,propID=pID,data=data})
     enc.call("APIrebuildButtons",{obj=obj})
   end
 end


### PR DESCRIPTION
Added APIobjCallProp(table)
Takes {obj=object,propID=property,color=Player.color,data=alt_click}

Calls given properties activateFunction, passing in obj,color, alt_click. Simulates button press.

Updated most modules to include alt_click support for menu buttons.
Can now reset some modules to default by right clicking the menu button for the property.